### PR TITLE
Add `depends_on:` to mark ocypod dependent on ocypod-redis in the example's docker-compose.yml

### DIFF
--- a/examples/ocypod-redis-docker/docker-compose.yml
+++ b/examples/ocypod-redis-docker/docker-compose.yml
@@ -8,6 +8,8 @@ services:
     command: /etc/ocypod.toml
     ports:
       - 8023:8023
+    depends_on:
+      - ocypod-redis
   ocypod-redis:
     image: redis:6
     ports:


### PR DESCRIPTION
Although rare, the following error happens when the container of ocypod starting before ocypod-redis:

```
$ docker compose up
[+] Building 0.0s (0/0)
[+] Running 2/0
 ✔ Container ocypod-ocypod-1        Recreated                                                        0.1s
 ✔ Container ocypod-ocypod-redis-1  Created                                                          0.0s
Attaching to ocypod-ocypod-1, ocypod-ocypod-redis-1
ocypod-ocypod-1        | [2023-06-27T05:17:45Z DEBUG] Log initialised using: ocypod=DEBUG,ocypod-server=DEBUG
ocypod-ocypod-1        | [2023-06-27T05:17:45Z DEBUG] Initialised Redis connection pool to redis://ocypod-redis
ocypod-ocypod-1        | Failed to initialise queues from configuration file: Failed to connect to Redis: Error occurred while creating a new object: Connection refused (os error 111)
ocypod-ocypod-redis-1  | 1:C 27 Jun 2023 05:17:45.435 # oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo
ocypod-ocypod-redis-1  | 1:C 27 Jun 2023 05:17:45.435 # Redis version=6.2.12, bits=64, commit=00000000, modified=0, pid=1, just started
ocypod-ocypod-redis-1  | 1:C 27 Jun 2023 05:17:45.435 # Warning: no config file specified, using the default config. In order to specify a config file use redis-server /path/to/redis.conf
ocypod-ocypod-redis-1  | 1:M 27 Jun 2023 05:17:45.436 * monotonic clock: POSIX clock_gettime
ocypod-ocypod-redis-1  | 1:M 27 Jun 2023 05:17:45.436 * Running mode=standalone, port=6379.
ocypod-ocypod-redis-1  | 1:M 27 Jun 2023 05:17:45.436 # Server initialized
ocypod-ocypod-redis-1  | 1:M 27 Jun 2023 05:17:45.436 # WARNING Memory overcommit must be enabled! Without it, a background save or replication may fail under low memory condition. Being disabled, it can can also cause failures without low memory condition, see https://github.com/jemalloc/jemalloc/issues/1328. To fix this issue add 'vm.overcommit_memory = 1' to /etc/sysctl.conf and then reboot or run the command 'sysctl vm.overcommit_memory=1' for this to take effect.
ocypod-ocypod-redis-1  | 1:M 27 Jun 2023 05:17:45.437 * Loading RDB produced by version 6.2.12
ocypod-ocypod-redis-1  | 1:M 27 Jun 2023 05:17:45.437 * RDB age 105 seconds
ocypod-ocypod-redis-1  | 1:M 27 Jun 2023 05:17:45.437 * RDB memory usage when created 0.77 Mb
ocypod-ocypod-redis-1  | 1:M 27 Jun 2023 05:17:45.437 # Done loading RDB, keys loaded: 0, keys expired: 0.
ocypod-ocypod-redis-1  | 1:M 27 Jun 2023 05:17:45.437 * DB loaded from disk: 0.000 seconds
ocypod-ocypod-redis-1  | 1:M 27 Jun 2023 05:17:45.437 * Ready to accept connections
ocypod-ocypod-1 exited with code 1
```

I'm using the following docker version:

```
$ docker version
Client: Docker Engine - Community
 Version:           24.0.2
 API version:       1.43
 Go version:        go1.20.4
 Git commit:        cb74dfc
 Built:             Thu May 25 21:51:00 2023
 OS/Arch:           linux/amd64
 Context:           default

Server: Docker Engine - Community
 Engine:
  Version:          24.0.2
  API version:      1.43 (minimum version 1.12)
  Go version:       go1.20.4
  Git commit:       659604f
  Built:            Thu May 25 21:51:00 2023
  OS/Arch:          linux/amd64
  Experimental:     false
 containerd:
  Version:          1.6.21
  GitCommit:        3dce8eb055cbb6872793272b4f20ed16117344f8
 runc:
  Version:          1.1.7
  GitCommit:        v1.1.7-0-g860f061
 docker-init:
  Version:          0.19.0
  GitCommit:        de40ad0
```